### PR TITLE
Fix #44: local code coverage tooling (Coverlet + ReportGenerator)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,18 @@
       "Bash(dotnet test:*)",
       "Bash(gh issue:*)",
       "Bash(git add:*)",
-      "Bash(git commit -m ':*)"
+      "Bash(git commit -m ':*)",
+      "Bash(gh repo:*)",
+      "Bash(find src:*)",
+      "Bash(git push:*)",
+      "Bash(dotnet sln:*)",
+      "Bash(gh pr create --title 'Fix #38: HL7Net — HL7 v2.x parse, write, and DOM support' --body ':*)",
+      "Bash(grep -n \"\\\\\\\\[0\\\\\\\\]\\\\|\\\\\\\\[1\\\\\\\\]\\\\|\\\\\\\\[2\\\\\\\\]\\\\|\\\\\\\\[3\\\\\\\\]\\\\|\\\\\\\\[4\\\\\\\\]\\\\|\\\\\\\\[5\\\\\\\\]\\\\|\\\\\\\\[6\\\\\\\\]\" src/X12Net/**/*.cs)",
+      "Bash(xargs grep *)",
+      "Bash(dotnet new *)",
+      "Bash(dotnet tool *)",
+      "Bash(git stash *)",
+      "Bash(git checkout *)"
     ]
   }
 }

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-reportgenerator-globaltool": {
+      "version": "5.5.6",
+      "commands": [
+        "reportgenerator"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# coverage.sh — generate an HTML code coverage report for all test projects.
+#
+# Usage:
+#   bash scripts/coverage.sh            # run all tests, open report
+#   bash scripts/coverage.sh --no-open  # run all tests, skip auto-open
+#
+# Output: coverage/html/index.html
+# Requires: dotnet tool restore (installs ReportGenerator from .config/dotnet-tools.json)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RAW_DIR="$REPO_ROOT/coverage/raw"
+HTML_DIR="$REPO_ROOT/coverage/html"
+OPEN_REPORT=true
+
+for arg in "$@"; do
+  [[ "$arg" == "--no-open" ]] && OPEN_REPORT=false
+done
+
+echo "==> Restoring dotnet tools..."
+dotnet tool restore
+
+echo "==> Cleaning previous coverage data..."
+rm -rf "$RAW_DIR"
+
+echo "==> Running tests with coverage collection..."
+dotnet test "$REPO_ROOT/X12Net.sln" \
+  --collect:"XPlat Code Coverage" \
+  --results-directory "$RAW_DIR" \
+  --nologo
+
+echo "==> Generating HTML report..."
+dotnet tool run reportgenerator \
+  -reports:"$RAW_DIR/**/coverage.cobertura.xml" \
+  -targetdir:"$HTML_DIR" \
+  -reporttypes:"Html;TextSummary" \
+  -assemblyfilters:"+X12Net;+HL7Net" \
+  -verbosity:Warning
+
+echo ""
+echo "Coverage summary:"
+cat "$HTML_DIR/Summary.txt" 2>/dev/null || true
+
+echo ""
+echo "Full report: $HTML_DIR/index.html"
+
+if $OPEN_REPORT; then
+  # Open in default browser — works on Windows (Git Bash), macOS, and Linux
+  if command -v explorer.exe &>/dev/null; then
+    explorer.exe "$(cygpath -w "$HTML_DIR/index.html")"
+  elif command -v open &>/dev/null; then
+    open "$HTML_DIR/index.html"
+  elif command -v xdg-open &>/dev/null; then
+    xdg-open "$HTML_DIR/index.html"
+  fi
+fi

--- a/test/X12Net.Tests/X12Net.Tests.csproj
+++ b/test/X12Net.Tests/X12Net.Tests.csproj
@@ -20,6 +20,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Adds `coverlet.collector` to test projects for XPlat coverage collection
- Installs `dotnet-reportgenerator-globaltool` as a local dotnet tool (`.config/dotnet-tools.json`)
- Adds `scripts/coverage.sh` — one command generates a full HTML report and opens it in the browser

No CI/CD required. Runs entirely on demand locally.

## Usage

```bash
bash scripts/coverage.sh          # run tests, generate report, open in browser
bash scripts/coverage.sh --no-open  # skip auto-open
```

Output lands in `coverage/html/index.html` (already covered by `.gitignore`).

## Current numbers (288 tests, 2 assemblies)

| | Line | Branch | Method |
|---|---|---|---|
| **Overall** | 94.1% | 83.9% | 91.3% |
| X12Net | 93.7% | — | — |
| HL7Net | 97.1% | — | — |

Notable gaps (from `Summary.txt`):
- `X12Delimiters` — 50% (equality/hash members untested)
- `X12Tool` (CLI) — 75%
- `Ts270`, `Ts277`, `Ts837D`, `Ts837I`, `Ts999` — 72% (source-generated; parse paths not exercised)

## Test plan

- [x] `bash scripts/coverage.sh --no-open` completes without error
- [x] `coverage/html/index.html` and `coverage/html/Summary.txt` are generated
- [x] All 288 tests still pass

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)