### PR TITLE
Fix #43: centralise ISA magic numbers in X12Constants

### DIFF
--- a/src/X12Net.Application/Validation/X12Validator.cs
+++ b/src/X12Net.Application/Validation/X12Validator.cs
@@ -71,12 +71,12 @@ public static class X12Validator
         var isa = segments.First(s => s.SegmentId == "ISA");
 
         // ISA06 = sender ID (element index 6), ISA08 = receiver ID (element index 8)
-        // Each must be exactly 15 chars in the fixed-width ISA — raw value is already padded;
-        // we flag values that are longer than 15 before padding.
-        if (isa[6].TrimEnd().Length > 15)
+        // Each must be exactly X12Constants.IsaIdFieldWidth chars in the fixed-width ISA —
+        // raw value is already padded; we flag values that are longer before padding.
+        if (isa[6].TrimEnd().Length > X12Constants.IsaIdFieldWidth)
             errors.Add(new X12ValidationError(
                 X12ErrorCode.IsaSenderIdTooLong,
-                $"ISA06 sender ID '{isa[6].TrimEnd()}' exceeds 15 characters."));
+                $"ISA06 sender ID '{isa[6].TrimEnd()}' exceeds {X12Constants.IsaIdFieldWidth} characters."));
     }
 
     private static void CheckInterchangeControlNumber(

--- a/src/X12Net.Domain/Core/X12Constants.cs
+++ b/src/X12Net.Domain/Core/X12Constants.cs
@@ -1,0 +1,31 @@
+namespace woliver13.X12Net.Core;
+
+/// <summary>
+/// Centralised constants for ISA segment fixed-width field specifications.
+/// All values derive from the ANSI ASC X12 interchange control structure.
+/// </summary>
+internal static class X12Constants
+{
+    /// <summary>
+    /// Minimum character length of a well-formed ISA segment string (106 chars).
+    /// ISA01–ISA16 with element separators plus the segment terminator.
+    /// </summary>
+    internal const int IsaMinLength = 106;
+
+    /// <summary>
+    /// Length of the ISA segment body (105 chars), excluding the final segment terminator.
+    /// Used to validate that all fixed-width fields are correctly padded before appending the terminator.
+    /// </summary>
+    internal const int IsaBodyLength = 105;
+
+    /// <summary>
+    /// Number of data elements in the ISA segment (ISA01–ISA16 = 16 elements).
+    /// </summary>
+    internal const int IsaElementCount = 16;
+
+    /// <summary>
+    /// Fixed width of the ISA sender/receiver ID fields (ISA06 and ISA08), in characters.
+    /// Values shorter than 15 chars must be right-padded with spaces; longer values are invalid.
+    /// </summary>
+    internal const int IsaIdFieldWidth = 15;
+}

--- a/src/X12Net.Domain/Core/X12IsaParser.cs
+++ b/src/X12Net.Domain/Core/X12IsaParser.cs
@@ -7,20 +7,17 @@ namespace woliver13.X12Net.Core;
 /// </summary>
 internal static class X12IsaParser
 {
-    private const int IsaElementCount = 16;
-    private const int MinIsaLength    = 106;
-
     /// <summary>
     /// Parses delimiter characters from an ISA header.
     /// </summary>
     /// <exception cref="ArgumentException">
-    /// Input is null/empty, shorter than <see cref="MinIsaLength"/>, or does not start with "ISA".
+    /// Input is null/empty, shorter than <see cref="X12Constants.IsaMinLength"/>, or does not start with "ISA".
     /// </exception>
     internal static X12Delimiters Parse(string isaInput)
     {
-        if (string.IsNullOrEmpty(isaInput) || isaInput.Length < MinIsaLength)
+        if (string.IsNullOrEmpty(isaInput) || isaInput.Length < X12Constants.IsaMinLength)
             throw new ArgumentException(
-                $"ISA segment must be at least {MinIsaLength} characters.", nameof(isaInput));
+                $"ISA segment must be at least {X12Constants.IsaMinLength} characters.", nameof(isaInput));
 
         if (!isaInput.StartsWith("ISA", StringComparison.Ordinal))
             throw new ArgumentException("Input does not start with 'ISA'.", nameof(isaInput));
@@ -33,7 +30,7 @@ internal static class X12IsaParser
             if (isaInput[i] == elementSep)
             {
                 sepCount++;
-                if (sepCount == IsaElementCount - 1)
+                if (sepCount == X12Constants.IsaElementCount - 1)
                 {
                     char componentSep = i + 1 < isaInput.Length ? isaInput[i + 1] : ':';
                     char segmentTerm  = i + 2 < isaInput.Length ? isaInput[i + 2] : '~';

--- a/src/X12Net.Domain/Core/X12Tokenizer.cs
+++ b/src/X12Net.Domain/Core/X12Tokenizer.cs
@@ -7,7 +7,7 @@ namespace woliver13.X12Net.Core;
 /// </summary>
 public static class X12Tokenizer
 {
-    private const int MinIsaLength = 106;  // quick pre-check before delegating to X12IsaParser
+    // quick pre-check before delegating to X12IsaParser — see X12Constants.IsaMinLength
 
     // ── Public API ────────────────────────────────────────────────────────
 
@@ -34,7 +34,7 @@ public static class X12Tokenizer
             yield break;
 
         // Auto-detect when the input starts with ISA and is long enough
-        if (input.Length >= MinIsaLength && input.StartsWith("ISA", StringComparison.Ordinal))
+        if (input.Length >= X12Constants.IsaMinLength && input.StartsWith("ISA", StringComparison.Ordinal))
         {
             var d          = DetectDelimiters(input);
             elementSeparator   = d.ElementSeparator;

--- a/src/X12Net.Domain/Envelopes/X12InterchangeBuilder.cs
+++ b/src/X12Net.Domain/Envelopes/X12InterchangeBuilder.cs
@@ -195,11 +195,11 @@ public sealed class X12InterchangeBuilder
 
     private string BuildISA()
     {
-        // ISA is fixed-width: 106 characters total.
-        // Fields: ISA01-ISA16, delimited by element separator, closed by segment terminator at [105].
+        // ISA is fixed-width: X12Constants.IsaMinLength characters total.
+        // Fields: ISA01-ISA16, delimited by element separator, closed by segment terminator at [X12Constants.IsaBodyLength].
         string icnPadded      = _icn.ToString().PadLeft(9, '0');
-        string senderPadded   = _senderId.PadRight(15).Substring(0, 15);
-        string receiverPadded = _receiverId.PadRight(15).Substring(0, 15);
+        string senderPadded   = _senderId.PadRight(X12Constants.IsaIdFieldWidth).Substring(0, X12Constants.IsaIdFieldWidth);
+        string receiverPadded = _receiverId.PadRight(X12Constants.IsaIdFieldWidth).Substring(0, X12Constants.IsaIdFieldWidth);
 
         // The ISA segment, without terminator:
         // ISA*00*          *00*          *ZZ*<sender15>*ZZ*<receiver15>*<date>*<time>*<ISA11>*<ISA12>*<icn9>*0*P*<ISA16>
@@ -222,10 +222,10 @@ public sealed class X12InterchangeBuilder
             $"P{_elementSep}" +
             $"{_componentSep}";
 
-        // body must be exactly 105 chars before the terminator
-        if (body.Length != 105)
+        // body must be exactly X12Constants.IsaBodyLength chars before the terminator
+        if (body.Length != X12Constants.IsaBodyLength)
             throw new InvalidOperationException(
-                $"ISA body is {body.Length} chars; expected 105. Check field widths.");
+                $"ISA body is {body.Length} chars; expected {X12Constants.IsaBodyLength}. Check field widths.");
 
         return body + _segmentTerm;
     }

--- a/test/X12Net.Tests/Core/X12ConstantsTests.cs
+++ b/test/X12Net.Tests/Core/X12ConstantsTests.cs
@@ -1,0 +1,24 @@
+using woliver13.X12Net.Core;
+
+namespace woliver13.X12Net.Tests.Core;
+
+public class X12ConstantsTests
+{
+    [Theory]
+    [InlineData(nameof(X12Constants.IsaMinLength),    106)]
+    [InlineData(nameof(X12Constants.IsaBodyLength),   105)]
+    [InlineData(nameof(X12Constants.IsaElementCount),  16)]
+    [InlineData(nameof(X12Constants.IsaIdFieldWidth),  15)]
+    public void X12Constants_defines_ISA_field_widths(string name, int expected)
+    {
+        var actual = name switch
+        {
+            nameof(X12Constants.IsaMinLength)    => X12Constants.IsaMinLength,
+            nameof(X12Constants.IsaBodyLength)   => X12Constants.IsaBodyLength,
+            nameof(X12Constants.IsaElementCount) => X12Constants.IsaElementCount,
+            nameof(X12Constants.IsaIdFieldWidth) => X12Constants.IsaIdFieldWidth,
+            _ => throw new ArgumentOutOfRangeException(nameof(name))
+        };
+        actual.ShouldBe(expected);
+    }
+}


### PR DESCRIPTION
## Summary

Eliminates the ISA fixed-width field magic numbers that were duplicated independently across four files, replacing them with a single internal `X12Constants` class in the Domain core layer.

Closes #43

## Changes

**New file:** `src/X12Net.Domain/Core/X12Constants.cs`

| Constant | Value | Previously in |
|---|---|---|
| `IsaMinLength` | 106 | `X12Tokenizer.cs`, `X12IsaParser.cs` (each had its own local `const`) |
| `IsaBodyLength` | 105 | `X12InterchangeBuilder.cs` (inline literal) |
| `IsaElementCount` | 16 | `X12IsaParser.cs` (local `const`) |
| `IsaIdFieldWidth` | 15 | `X12InterchangeBuilder.cs`, `X12Validator.cs` (inline literals) |

**Updated:**
- `X12IsaParser` — removed local `const` fields, references `X12Constants`
- `X12Tokenizer` — removed local `const` field, references `X12Constants`
- `X12InterchangeBuilder` — inline `105`, `15` replaced; also fixed `PadRight(15).Substring(0,15)` to use named constant
- `X12Validator` — inline `15` replaced

**New test:** `X12ConstantsTests` — `[Theory]` pinning all four constant values (4 cases)

## Test plan

- [x] 4 new `X12ConstantsTests` pass
- [x] Full solution: 300 tests (269 X12Net + 31 HL7Net), all passing
- [x] Builds clean on both `net8.0` and `netstandard2.0` targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)