### PR TITLE
Fix #54: centralise duplicate EDI test strings in Fixtures/Edi

### DIFF
--- a/test/X12Net.Tests/CLI/X12ToolServiceTests.cs
+++ b/test/X12Net.Tests/CLI/X12ToolServiceTests.cs
@@ -5,15 +5,7 @@ namespace woliver13.X12Net.Tests.CLI;
 
 public class X12ToolServiceTests
 {
-    private const string ValidInterchange =
-        "ISA*00*          *00*          *ZZ*SENDER         *ZZ*RECEIVER       *201909*1200*^*00501*000000001*0*P*:~" +
-        "GS*FA*SENDER*RECEIVER*20190901*1200*1*X*005010X231A1~" +
-        "ST*999*0001~" +
-        "AK1*FA*1*005010X231A1~" +
-        "AK9*A*1*1*1~" +
-        "SE*4*0001~" +
-        "GE*1*1~" +
-        "IEA*1*000000001~";
+    private const string ValidInterchange = Fixtures.Edi.Valid999;
 
     private static IX12ToolService BuildService()
     {

--- a/test/X12Net.Tests/DOM/X12DocumentTests.cs
+++ b/test/X12Net.Tests/DOM/X12DocumentTests.cs
@@ -4,9 +4,7 @@ namespace woliver13.X12Net.Tests.DOM;
 
 public class X12DocumentTests
 {
-    private const string TwoSegmentInput =
-        "ISA*00*          *00*          *ZZ*SENDER         *ZZ*RECEIVER       *201909*1200*^*00501*000000001*0*P*:~" +
-        "GS*FA*SENDER*RECEIVER*20190901*1200*1*X*005010X231A1~";
+    private const string TwoSegmentInput = Fixtures.Edi.IsaGs;
 
     [Fact]
     public void Document_provides_segment_access_by_index()
@@ -134,15 +132,7 @@ public class X12DocumentTests
 
     // ── Cycle 3 (Phase 6) ─────────────────────────────────────────────────
 
-    private const string FullInterchange =
-        "ISA*00*          *00*          *ZZ*SENDER         *ZZ*RECEIVER       *201909*1200*^*00501*000000001*0*P*:~" +
-        "GS*FA*SENDER*RECEIVER*20190901*1200*1*X*005010X231A1~" +
-        "ST*999*0001~" +
-        "AK1*FA*1*005010X231A1~" +
-        "AK9*A*1*1*1~" +
-        "SE*4*0001~" +
-        "GE*1*1~" +
-        "IEA*1*000000001~";
+    private const string FullInterchange = Fixtures.Edi.Valid999;
 
     [Fact]
     public void Document_edit_roundtrips_correctly()

--- a/test/X12Net.Tests/DOM/X12InterchangeTests.cs
+++ b/test/X12Net.Tests/DOM/X12InterchangeTests.cs
@@ -5,15 +5,7 @@ namespace woliver13.X12Net.Tests.DOM;
 public class X12InterchangeTests
 {
     // Full interchange: ISA + GS + ST + data + SE + GE + IEA
-    private const string FullInterchange =
-        "ISA*00*          *00*          *ZZ*SENDER         *ZZ*RECEIVER       *201909*1200*^*00501*000000001*0*P*:~" +
-        "GS*FA*SENDER*RECEIVER*20190901*1200*1*X*005010X231A1~" +
-        "ST*999*0001~" +
-        "AK1*FA*1*005010X231A1~" +
-        "AK9*A*1*1*1~" +
-        "SE*4*0001~" +
-        "GE*1*1~" +
-        "IEA*1*000000001~";
+    private const string FullInterchange = Fixtures.Edi.Valid999;
 
     // Two functional groups inside one interchange
     private const string TwoGroupInterchange =

--- a/test/X12Net.Tests/DOM/X12TransactionTests.cs
+++ b/test/X12Net.Tests/DOM/X12TransactionTests.cs
@@ -8,15 +8,7 @@ public class X12TransactionTests
 {
     private static readonly X12Delimiters Delimiters = X12Delimiters.Default;
 
-    private const string FullInterchange =
-        "ISA*00*          *00*          *ZZ*SENDER         *ZZ*RECEIVER       *201909*1200*^*00501*000000001*0*P*:~" +
-        "GS*FA*SENDER*RECEIVER*20190901*1200*1*X*005010X231A1~" +
-        "ST*999*0001~" +
-        "AK1*FA*1*005010X231A1~" +
-        "AK9*A*1*1*1~" +
-        "SE*4*0001~" +
-        "GE*1*1~" +
-        "IEA*1*000000001~";
+    private const string FullInterchange = Fixtures.Edi.Valid999;
 
     // ── Cycle 4 ───────────────────────────────────────────────────────────
 

--- a/test/X12Net.Tests/Fixtures/Edi.cs
+++ b/test/X12Net.Tests/Fixtures/Edi.cs
@@ -1,0 +1,23 @@
+namespace woliver13.X12Net.Tests.Fixtures;
+
+/// <summary>
+/// Shared EDI sample interchanges referenced across multiple test classes.
+/// </summary>
+internal static class Edi
+{
+    /// <summary>ISA header + GS segment only (no transactions, no closing envelope).</summary>
+    internal const string IsaGs =
+        "ISA*00*          *00*          *ZZ*SENDER         *ZZ*RECEIVER       *201909*1200*^*00501*000000001*0*P*:~" +
+        "GS*FA*SENDER*RECEIVER*20190901*1200*1*X*005010X231A1~";
+
+    /// <summary>Complete single-transaction 999 functional acknowledgement interchange.</summary>
+    internal const string Valid999 =
+        "ISA*00*          *00*          *ZZ*SENDER         *ZZ*RECEIVER       *201909*1200*^*00501*000000001*0*P*:~" +
+        "GS*FA*SENDER*RECEIVER*20190901*1200*1*X*005010X231A1~" +
+        "ST*999*0001~" +
+        "AK1*FA*1*005010X231A1~" +
+        "AK9*A*1*1*1~" +
+        "SE*4*0001~" +
+        "GE*1*1~" +
+        "IEA*1*000000001~";
+}

--- a/test/X12Net.Tests/IO/X12ReaderTests.cs
+++ b/test/X12Net.Tests/IO/X12ReaderTests.cs
@@ -6,9 +6,7 @@ namespace woliver13.X12Net.Tests.IO;
 public class X12ReaderTests
 {
     // Two-segment interchange: ISA + GS (no IEA/GE for brevity)
-    private const string SimpleInput =
-        "ISA*00*          *00*          *ZZ*SENDER         *ZZ*RECEIVER       *201909*1200*^*00501*000000001*0*P*:~" +
-        "GS*FA*SENDER*RECEIVER*20190901*1200*1*X*005010X231A1~";
+    private const string SimpleInput = Fixtures.Edi.IsaGs;
 
     [Fact]
     public void Reader_returns_all_segments_from_simple_interchange()

--- a/test/X12Net.Tests/Validation/X12InterchangeValidatorTests.cs
+++ b/test/X12Net.Tests/Validation/X12InterchangeValidatorTests.cs
@@ -4,15 +4,7 @@ namespace woliver13.X12Net.Tests.Validation;
 
 public class X12InterchangeValidatorTests
 {
-    private const string ValidInterchange =
-        "ISA*00*          *00*          *ZZ*SENDER         *ZZ*RECEIVER       *201909*1200*^*00501*000000001*0*P*:~" +
-        "GS*FA*SENDER*RECEIVER*20190901*1200*1*X*005010X231A1~" +
-        "ST*999*0001~" +
-        "AK1*FA*1*005010X231A1~" +
-        "AK9*A*1*1*1~" +
-        "SE*4*0001~" +
-        "GE*1*1~" +
-        "IEA*1*000000001~";
+    private const string ValidInterchange = Fixtures.Edi.Valid999;
 
     private const string MismatchedControlNumber =
         "ISA*00*          *00*          *ZZ*SENDER         *ZZ*RECEIVER       *201909*1200*^*00501*000000001*0*P*:~" +

--- a/test/X12Net.Tests/Validation/X12ValidatorTests.cs
+++ b/test/X12Net.Tests/Validation/X12ValidatorTests.cs
@@ -26,15 +26,7 @@ public class X12ValidatorTests
     }
 
 
-    private const string ValidInterchange =
-        "ISA*00*          *00*          *ZZ*SENDER         *ZZ*RECEIVER       *201909*1200*^*00501*000000001*0*P*:~" +
-        "GS*FA*SENDER*RECEIVER*20190901*1200*1*X*005010X231A1~" +
-        "ST*999*0001~" +
-        "AK1*FA*1*005010X231A1~" +
-        "AK9*A*1*1*1~" +
-        "SE*4*0001~" +
-        "GE*1*1~" +
-        "IEA*1*000000001~";
+    private const string ValidInterchange = Fixtures.Edi.Valid999;
 
     // ── Cycle 1 ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Add `test/X12Net.Tests/Fixtures/Edi.cs` with a static `Edi` class exposing two shared constants: `Edi.Valid999` (a complete single-transaction 999 ACK interchange) and `Edi.IsaGs` (an ISA+GS header-only fragment)
- Replace 8 copy-pasted inline EDI string constants across 8 test files with references to the shared fixture
- Closes #54

## Test plan

- [x] `dotnet test` — all 269 tests pass, no regressions
- [x] Each updated test file compiles and references the correct fixture member

🤖 Generated with [Claude Code](https://claude.com/claude-code)