### PR TITLE
Fix #55: replace pre-.NET 6 null-guard pattern with ThrowHelper.ThrowIfNull

### DIFF
--- a/src/HL7Net/IO/Hl7Reader.cs
+++ b/src/HL7Net/IO/Hl7Reader.cs
@@ -19,7 +19,8 @@ public sealed class Hl7Reader
     /// <param name="maxSegments">Maximum segments to read before throwing. Defaults to 10 000.</param>
     public Hl7Reader(string text, int maxSegments = DefaultMaxSegments)
     {
-        _text        = text ?? throw new ArgumentNullException(nameof(text));
+        ThrowHelper.ThrowIfNull(text, nameof(text));
+        _text        = text;
         _maxSegments = maxSegments;
     }
 

--- a/src/HL7Net/IO/Hl7Writer.cs
+++ b/src/HL7Net/IO/Hl7Writer.cs
@@ -12,7 +12,8 @@ public sealed class Hl7Writer
     /// <summary>Initializes an <see cref="Hl7Writer"/> with the given delimiters.</summary>
     public Hl7Writer(Hl7Delimiters delimiters)
     {
-        _delimiters = delimiters ?? throw new ArgumentNullException(nameof(delimiters));
+        ThrowHelper.ThrowIfNull(delimiters, nameof(delimiters));
+        _delimiters = delimiters;
     }
 
     /// <summary>

--- a/src/HL7Net/ThrowHelper.cs
+++ b/src/HL7Net/ThrowHelper.cs
@@ -1,0 +1,11 @@
+namespace woliver13.HL7Net.IO;
+
+// Backport of ArgumentNullException.ThrowIfNull for netstandard2.0 builds.
+internal static class ThrowHelper
+{
+    internal static void ThrowIfNull(object? argument, string paramName)
+    {
+        if (argument is null)
+            throw new ArgumentNullException(paramName);
+    }
+}

--- a/src/X12Net.Domain/Envelopes/X12InterchangeBuilder.cs
+++ b/src/X12Net.Domain/Envelopes/X12InterchangeBuilder.cs
@@ -255,5 +255,5 @@ public sealed class X12InterchangeBuilder
 
     // Truncates value to width if it is too long; pads with spaces on the right if it is too short.
     private static string FixedWidth(string value, int width) =>
-        value.Length >= width ? value[..width] : value.PadRight(width);
+        value.Length >= width ? value.Substring(0, width) : value.PadRight(width);
 }

--- a/src/X12Net.Infrastructure/IO/X12Reader.cs
+++ b/src/X12Net.Infrastructure/IO/X12Reader.cs
@@ -32,7 +32,8 @@ public sealed class X12Reader : IDisposable
     /// <param name="logger">Optional logger; defaults to <see cref="NullLogger{T}.Instance"/>.</param>
     public X12Reader(string input, int maxSegments = 0, ILogger<X12Reader>? logger = null)
     {
-        _input       = input ?? throw new ArgumentNullException(nameof(input));
+        ThrowHelper.ThrowIfNull(input, nameof(input));
+        _input       = input;
         _maxSegments = maxSegments;
         _logger      = logger ?? NullLogger<X12Reader>.Instance;
     }
@@ -43,7 +44,8 @@ public sealed class X12Reader : IDisposable
     /// <param name="logger">Optional logger; defaults to <see cref="NullLogger{T}.Instance"/>.</param>
     public X12Reader(string input, X12Delimiters delimiters, int maxSegments = 0, ILogger<X12Reader>? logger = null)
     {
-        _input       = input ?? throw new ArgumentNullException(nameof(input));
+        ThrowHelper.ThrowIfNull(input, nameof(input));
+        _input       = input;
         _delimiters  = delimiters;
         _maxSegments = maxSegments;
         _logger      = logger ?? NullLogger<X12Reader>.Instance;
@@ -72,7 +74,8 @@ public sealed class X12Reader : IDisposable
     /// </remarks>
     public X12Reader(Stream stream, Encoding? encoding = null, int maxSegments = 0, ILogger<X12Reader>? logger = null)
     {
-        _stream      = stream ?? throw new ArgumentNullException(nameof(stream));
+        ThrowHelper.ThrowIfNull(stream, nameof(stream));
+        _stream      = stream;
         _encoding    = encoding;
         _maxSegments = maxSegments;
         _logger      = logger ?? NullLogger<X12Reader>.Instance;

--- a/src/X12Net.Infrastructure/ThrowHelper.cs
+++ b/src/X12Net.Infrastructure/ThrowHelper.cs
@@ -1,0 +1,11 @@
+namespace woliver13.X12Net.IO;
+
+// Backport of ArgumentNullException.ThrowIfNull for netstandard2.0 builds.
+internal static class ThrowHelper
+{
+    internal static void ThrowIfNull(object? argument, string paramName)
+    {
+        if (argument is null)
+            throw new ArgumentNullException(paramName);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ThrowHelper` internal static class to `X12Net.Infrastructure` and `HL7Net` — a netstandard2.0-compatible backport of `ArgumentNullException.ThrowIfNull`
- Replace five `?? throw new ArgumentNullException(nameof(...))` call sites in `X12Reader`, `Hl7Reader`, and `Hl7Writer` with `ThrowHelper.ThrowIfNull`
- Also fix a latent netstandard2.0 build error introduced in #53: replace the C# 8 range operator `value[..width]` in `X12InterchangeBuilder.FixedWidth` with `value.Substring(0, width)`
- Closes #55

## Test plan

- [x] `dotnet build` — no errors across all TFMs (net8.0 + netstandard2.0)
- [x] `dotnet test` — all 269 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)