### PR TITLE
Fix #45: extract X12MessageParser to eliminate duplicated parse logic

### DIFF
--- a/src/X12Net.Domain/Core/X12MessageParser.cs
+++ b/src/X12Net.Domain/Core/X12MessageParser.cs
@@ -1,0 +1,11 @@
+namespace woliver13.X12Net.Core;
+
+internal static class X12MessageParser
+{
+    internal static (List<X12Segment> Segments, X12Delimiters Delimiters)
+        Parse(string input)
+    {
+        var delimiters = X12Delimiters.FromIsa(input);
+        return (X12SegmentParser.ParseAll(input, delimiters).ToList(), delimiters);
+    }
+}

--- a/src/X12Net.Domain/DOM/X12Document.cs
+++ b/src/X12Net.Domain/DOM/X12Document.cs
@@ -36,10 +36,9 @@ public sealed class X12Document
     /// <summary>Parses raw EDI X12 text into an <see cref="X12Document"/>.</summary>
     public static X12Document Parse(string input)
     {
-        var d = X12Delimiters.FromIsa(input);
+        var (raw, d) = X12MessageParser.Parse(input);
 
-        var segments = X12SegmentParser
-            .ParseAll(input, d)
+        var segments = raw
             .Select(s => new X12MutableSegment(s.SegmentId, s.Elements))
             .ToList();
 

--- a/src/X12Net.Domain/DOM/X12Interchange.cs
+++ b/src/X12Net.Domain/DOM/X12Interchange.cs
@@ -75,8 +75,7 @@ public sealed class X12Interchange
     /// <summary>Parses a raw EDI X12 interchange into a hierarchical <see cref="X12Interchange"/>.</summary>
     public static X12Interchange Parse(string input)
     {
-        var delimiters = X12Delimiters.FromIsa(input);
-        var all = X12SegmentParser.ParseAll(input, delimiters).ToList();
+        var (all, delimiters) = X12MessageParser.Parse(input);
         return Build(all, delimiters);
     }
 

--- a/test/X12Net.Tests/DOM/X12DocumentTests.cs
+++ b/test/X12Net.Tests/DOM/X12DocumentTests.cs
@@ -147,4 +147,48 @@ public class X12DocumentTests
         reparsed["GS", 1].ShouldBe("FA");
         reparsed["GS", 3].ShouldBe("RECEIVER");
     }
+
+    // ── X12MessageParser characterisation tests ───────────────────────────
+
+    // ISA header using | as element sep, ^ as component sep, \n as segment terminator
+    private const string NonstandardDelimiterInterchange =
+        "ISA|00|          |00|          |ZZ|SENDER         |ZZ|RECEIVER       |201909|1200|^|00501|000000001|0|P|:\n" +
+        "GS|FA|SENDER|RECEIVER|20190901|1200|1|X|005010X231A1\n" +
+        "ST|999|0001\n" +
+        "SE|1|0001\n" +
+        "GE|1|1\n" +
+        "IEA|1|000000001\n";
+
+    [Fact]
+    public void Both_Parse_methods_detect_identical_delimiters_for_nonstandard_interchange()
+    {
+        var doc         = X12Document.Parse(NonstandardDelimiterInterchange);
+        var interchange = X12Interchange.Parse(NonstandardDelimiterInterchange);
+
+        doc.Delimiters.ElementSeparator.ShouldBe(interchange.Delimiters.ElementSeparator);
+        doc.Delimiters.ComponentSeparator.ShouldBe(interchange.Delimiters.ComponentSeparator);
+        doc.Delimiters.SegmentTerminator.ShouldBe(interchange.Delimiters.SegmentTerminator);
+
+        doc.Delimiters.ElementSeparator.ShouldBe('|');
+        doc.Delimiters.ComponentSeparator.ShouldBe(':');
+        doc.Delimiters.SegmentTerminator.ShouldBe('\n');
+    }
+
+    [Fact]
+    public void Both_Parse_methods_yield_same_segment_count_from_same_input()
+    {
+        var doc         = X12Document.Parse(Fixtures.Edi.Valid999);
+        var interchange = X12Interchange.Parse(Fixtures.Edi.Valid999);
+
+        // X12Document counts all segments; X12Interchange exposes them via ISA+groups+IEA
+        int interchangeSegmentCount =
+            1 // ISA
+            + interchange.FunctionalGroups.Sum(g =>
+                1 // GS
+                + g.Transactions.Sum(t => 1 + t.Segments.Count + 1) // ST + body + SE
+                + 1) // GE
+            + 1; // IEA
+
+        doc.Segments.Count.ShouldBe(interchangeSegmentCount);
+    }
 }


### PR DESCRIPTION
## Summary

- Extracts `internal static X12MessageParser` in `src/X12Net.Domain/Core/` that centralises delimiter detection (`X12Delimiters.FromIsa`) and segment tokenisation (`X12SegmentParser.ParseAll`) into a single call
- Updates `X12Document.Parse` and `X12Interchange.Parse` to delegate to `X12MessageParser.Parse` instead of duplicating the two-line pattern
- Adds two characterisation tests that pin cross-API consistency (delimiter detection and segment count) as a regression safety net

## Test plan

- [x] Cycle 1: `Both_Parse_methods_detect_identical_delimiters_for_nonstandard_interchange` — GREEN
- [x] Cycle 2: `Both_Parse_methods_yield_same_segment_count_from_same_input` — GREEN
- [x] Full suite: 273 passing, 0 failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)