### PR TITLE
Fix #50: guard X12SchemaRegistry against silent schema overwrites

### DIFF
--- a/src/X12Net.Domain/Schema/X12SchemaRegistry.cs
+++ b/src/X12Net.Domain/Schema/X12SchemaRegistry.cs
@@ -9,9 +9,24 @@ public sealed class X12SchemaRegistry
     private readonly Dictionary<string, X12TransactionSchema> _schemas =
         new(StringComparer.OrdinalIgnoreCase);
 
-    /// <summary>Registers or replaces a transaction schema.</summary>
-    public void Register(X12TransactionSchema schema) =>
-        _schemas[schema.TransactionSetId] = schema;
+    private bool _frozen;
+
+    /// <summary>Whether the registry has been frozen and accepts no further registrations.</summary>
+    public bool IsReadOnly => _frozen;
+
+    /// <summary>Prevents any further schema registrations.</summary>
+    public void Freeze() => _frozen = true;
+
+    /// <summary>Registers a transaction schema. Throws if the ID is already registered or the registry is frozen.</summary>
+    /// <exception cref="InvalidOperationException">A schema with the same transaction set ID is already registered, or the registry is frozen.</exception>
+    public void Register(X12TransactionSchema schema)
+    {
+        if (_frozen)
+            throw new InvalidOperationException("The registry is frozen and cannot accept new schemas.");
+        if (!TryRegister(schema))
+            throw new InvalidOperationException(
+                $"A schema for transaction set '{schema.TransactionSetId}' is already registered.");
+    }
 
     /// <summary>
     /// Returns the schema for <paramref name="transactionSetId"/>,
@@ -19,6 +34,18 @@ public sealed class X12SchemaRegistry
     /// </summary>
     public X12TransactionSchema? Get(string transactionSetId) =>
         _schemas.TryGetValue(transactionSetId, out var s) ? s : null;
+
+    /// <summary>
+    /// Attempts to register a schema. Returns <c>true</c> if registered;
+    /// <c>false</c> if a schema with the same ID already exists (no overwrite).
+    /// </summary>
+    public bool TryRegister(X12TransactionSchema schema)
+    {
+        if (_frozen || _schemas.ContainsKey(schema.TransactionSetId))
+            return false;
+        _schemas[schema.TransactionSetId] = schema;
+        return true;
+    }
 
     /// <summary>All registered schemas.</summary>
     public IReadOnlyCollection<X12TransactionSchema> All => _schemas.Values;

--- a/test/X12Net.Tests/Schema/X12SchemaTests.cs
+++ b/test/X12Net.Tests/Schema/X12SchemaTests.cs
@@ -188,6 +188,66 @@ public class X12SchemaTests
         Should.Throw<KeyNotFoundException>(() => _ = tx["MISSING", "Field1"]);
     }
 
+    // ── Issue #50: duplicate-guard and freeze ────────────────────────────
+
+    [Fact]
+    public void Register_throws_when_same_id_already_registered()
+    {
+        var registry = new X12SchemaRegistry();
+        var schema = new X12TransactionSchema("271", "Eligibility Response",
+            new X12SegmentSchema("EB", new[] { "EligibilityCode" }));
+
+        registry.Register(schema);
+
+        Should.Throw<InvalidOperationException>(() =>
+            registry.Register(new X12TransactionSchema("271", "Duplicate",
+                new X12SegmentSchema("EB", new[] { "EligibilityCode" }))));
+    }
+
+    [Fact]
+    public void TryRegister_registers_new_schema_and_returns_true()
+    {
+        var registry = new X12SchemaRegistry();
+        var schema = new X12TransactionSchema("270", "Eligibility Inquiry",
+            new X12SegmentSchema("BHT", new[] { "Code" }));
+
+        var result = registry.TryRegister(schema);
+
+        result.ShouldBeTrue();
+        registry.Get("270").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void TryRegister_returns_false_and_leaves_existing_schema_intact()
+    {
+        var registry = new X12SchemaRegistry();
+        var original = new X12TransactionSchema("271", "Original",
+            new X12SegmentSchema("EB", new[] { "EligibilityCode" }));
+        registry.Register(original);
+
+        var result = registry.TryRegister(new X12TransactionSchema("271", "Replacement",
+            new X12SegmentSchema("EB", new[] { "EligibilityCode" })));
+
+        result.ShouldBeFalse();
+        registry.Get("271")!.Description.ShouldBe("Original");
+    }
+
+    [Fact]
+    public void Freeze_makes_registry_read_only_and_throws_on_Register()
+    {
+        var registry = new X12SchemaRegistry();
+        registry.Register(new X12TransactionSchema("271", "Eligibility Response",
+            new X12SegmentSchema("EB", new[] { "EligibilityCode" })));
+
+        registry.IsReadOnly.ShouldBeFalse();
+        registry.Freeze();
+        registry.IsReadOnly.ShouldBeTrue();
+
+        Should.Throw<InvalidOperationException>(() =>
+            registry.Register(new X12TransactionSchema("270", "Eligibility Inquiry",
+                new X12SegmentSchema("BHT", new[] { "Code" }))));
+    }
+
     // ── Cycle 12 ──────────────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary

- `Register` throws `InvalidOperationException` on duplicate transaction set ID, eliminating silent overwrites
- `TryRegister` added as an opt-in overwrite-safe alternative — returns `false` for duplicates or when frozen
- `Freeze()` / `IsReadOnly` added to lock the registry after setup, so late registrations are caught at the call site
- Both `Register` and `TryRegister` respect the frozen state

## Test plan

- [x] Cycle 1: `Register_throws_when_same_id_already_registered` — RED → GREEN
- [x] Cycle 2: `TryRegister_registers_new_schema_and_returns_true` — RED → GREEN
- [x] Cycle 3: `TryRegister_returns_false_and_leaves_existing_schema_intact` — GREEN (characterisation)
- [x] Cycle 4: `Freeze_makes_registry_read_only_and_throws_on_Register` — RED → GREEN
- [x] Full suite: 277 passing, 0 failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)