### PR TITLE
Fix #49: add .editorconfig and enable NET analyzers via Directory.Build.props

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,97 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = crlf
+indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.cs]
+indent_size = 4
+
+# Usings
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+# this. qualification — not used; codebase uses _fields instead
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Language keywords over BCL type names (string, int, bool …)
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# var preferences
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = false:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = when_on_single_line:suggestion
+csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_expression_bodied_constructors = false:suggestion
+
+# Braces
+csharp_prefer_braces = when_multiline:suggestion
+
+# New-line placement
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+
+# ── Naming conventions ────────────────────────────────────────────────────
+
+# Private fields → _camelCase
+dotnet_naming_rule.private_fields_underscore_camel.symbols  = private_fields
+dotnet_naming_rule.private_fields_underscore_camel.style    = underscore_camel_case
+dotnet_naming_rule.private_fields_underscore_camel.severity = suggestion
+
+dotnet_naming_symbols.private_fields.applicable_kinds          = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+
+dotnet_naming_style.underscore_camel_case.capitalization    = camel_case
+dotnet_naming_style.underscore_camel_case.required_prefix   = _
+
+# Interfaces → IPascalCase
+dotnet_naming_rule.interfaces_prefix_i.symbols  = interfaces
+dotnet_naming_rule.interfaces_prefix_i.style    = prefix_i
+dotnet_naming_rule.interfaces_prefix_i.severity = warning
+
+dotnet_naming_symbols.interfaces.applicable_kinds          = interface
+dotnet_naming_symbols.interfaces.applicable_accessibilities = public, internal
+
+dotnet_naming_style.prefix_i.capitalization  = pascal_case
+dotnet_naming_style.prefix_i.required_prefix = I
+
+# Type parameters → TPascalCase
+dotnet_naming_rule.type_params_prefix_t.symbols  = type_params
+dotnet_naming_rule.type_params_prefix_t.style    = prefix_t
+dotnet_naming_rule.type_params_prefix_t.severity = suggestion
+
+dotnet_naming_symbols.type_params.applicable_kinds = type_parameter
+
+dotnet_naming_style.prefix_t.capitalization  = pascal_case
+dotnet_naming_style.prefix_t.required_prefix = T
+
+# Public / internal members → PascalCase
+dotnet_naming_rule.public_members_pascal.symbols  = public_members
+dotnet_naming_rule.public_members_pascal.style    = pascal_case
+dotnet_naming_rule.public_members_pascal.severity = suggestion
+
+dotnet_naming_symbols.public_members.applicable_kinds          = property, method, event, class, struct, enum, delegate
+dotnet_naming_symbols.public_members.applicable_accessibilities = public, internal, protected, protected_internal
+
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+[*.{csproj,props,targets}]
+indent_size = 2
+
+[*.{json,yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,4 +14,10 @@
     <!-- Set ContinuousIntegrationBuild automatically when running in GitHub Actions -->
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
+
+  <!-- Explicitly opt-in to SDK-bundled .NET platform analyzers (default on net5+; making it visible here) -->
+  <PropertyGroup Condition="'$(IsRoslynComponent)' != 'true'">
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisMode>Default</AnalysisMode>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

- Adds `.editorconfig` at the repo root encoding the conventions already present in the codebase: 4-space C# indentation, `_camelCase` private fields, PascalCase public/internal members, `I`-prefixed interfaces, `T`-prefixed type parameters, CRLF line endings, UTF-8 encoding
- Adds `EnableNETAnalyzers = true` and `AnalysisMode = Default` to `Directory.Build.props` (scoped to non-Roslyn projects) so SDK-bundled platform analyzers are explicitly opted-in rather than relying on the silent default — no explicit package reference needed since the .NET SDK bundles them for all targeted TFMs

## Notes

- `Microsoft.CodeAnalysis.NetAnalyzers` is already bundled by the .NET SDK for `net8.0` and `netstandard2.0` targets; adding the package explicitly would generate a version-mismatch warning on machines running a newer SDK, so `EnableNETAnalyzers = true` is the correct mechanism
- `EnforceExtendedAnalyzerRules` is left on `X12Net.SourceGenerator.csproj` only (it's a Roslyn component setting, not applicable to library projects)

## Test plan

- [x] `dotnet build src/X12Net/X12Net.csproj` — no new errors or warnings introduced
- [x] Full test suite: 277 passing, 0 failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)