### PR TITLE
Fix #40: track and expose X12 repetition separator from ISA11

### DIFF
--- a/src/X12Net.Domain/Core/X12Delimiters.cs
+++ b/src/X12Net.Domain/Core/X12Delimiters.cs
@@ -7,11 +7,16 @@ namespace woliver13.X12Net.Core;
 public readonly struct X12Delimiters : IEquatable<X12Delimiters>
 {
     /// <summary>Initializes delimiter values.</summary>
-    public X12Delimiters(char elementSeparator, char componentSeparator, char segmentTerminator)
+    public X12Delimiters(
+        char elementSeparator,
+        char componentSeparator,
+        char segmentTerminator,
+        char repetitionSeparator = '^')
     {
-        ElementSeparator   = elementSeparator;
-        ComponentSeparator = componentSeparator;
-        SegmentTerminator  = segmentTerminator;
+        ElementSeparator    = elementSeparator;
+        ComponentSeparator  = componentSeparator;
+        SegmentTerminator   = segmentTerminator;
+        RepetitionSeparator = repetitionSeparator;
     }
 
     /// <summary>Separates elements within a segment (ISA position 3; typically <c>*</c>).</summary>
@@ -23,8 +28,11 @@ public readonly struct X12Delimiters : IEquatable<X12Delimiters>
     /// <summary>Terminates each segment (character after ISA16; typically <c>~</c>).</summary>
     public char SegmentTerminator { get; }
 
+    /// <summary>Separates repetitions within an element (ISA11 in 005010+; typically <c>^</c>).</summary>
+    public char RepetitionSeparator { get; }
+
     /// <summary>Default delimiters used when no ISA header is present.</summary>
-    public static readonly X12Delimiters Default = new('*', ':', '~');
+    public static readonly X12Delimiters Default = new('*', ':', '~', '^');
 
     /// <summary>
     /// Detects delimiters from an ISA header.
@@ -42,9 +50,10 @@ public readonly struct X12Delimiters : IEquatable<X12Delimiters>
 
     /// <inheritdoc/>
     public bool Equals(X12Delimiters other) =>
-        ElementSeparator   == other.ElementSeparator &&
-        ComponentSeparator == other.ComponentSeparator &&
-        SegmentTerminator  == other.SegmentTerminator;
+        ElementSeparator    == other.ElementSeparator   &&
+        ComponentSeparator  == other.ComponentSeparator &&
+        SegmentTerminator   == other.SegmentTerminator  &&
+        RepetitionSeparator == other.RepetitionSeparator;
 
     /// <inheritdoc/>
     public override bool Equals(object? obj) => obj is X12Delimiters d && Equals(d);
@@ -58,11 +67,12 @@ public readonly struct X12Delimiters : IEquatable<X12Delimiters>
             hash = hash * 31 + ElementSeparator.GetHashCode();
             hash = hash * 31 + ComponentSeparator.GetHashCode();
             hash = hash * 31 + SegmentTerminator.GetHashCode();
+            hash = hash * 31 + RepetitionSeparator.GetHashCode();
             return hash;
         }
     }
 
     /// <inheritdoc/>
     public override string ToString() =>
-        $"ElementSep='{ElementSeparator}' ComponentSep='{ComponentSeparator}' SegTerm='{SegmentTerminator}'";
+        $"ElementSep='{ElementSeparator}' ComponentSep='{ComponentSeparator}' SegTerm='{SegmentTerminator}' RepSep='{RepetitionSeparator}'";
 }

--- a/src/X12Net.Domain/Core/X12IsaParser.cs
+++ b/src/X12Net.Domain/Core/X12IsaParser.cs
@@ -22,24 +22,28 @@ internal static class X12IsaParser
         if (!isaInput.StartsWith("ISA", StringComparison.Ordinal))
             throw new ArgumentException("Input does not start with 'ISA'.", nameof(isaInput));
 
-        char elementSep = isaInput[3];
-        int  sepCount   = 0;
+        char elementSep    = isaInput[3];
+        int  sepCount      = 0;
+        char repetitionSep = '^'; // ISA11 default per X12 005010+
 
         for (int i = 4; i < isaInput.Length; i++)
         {
             if (isaInput[i] == elementSep)
             {
                 sepCount++;
+                if (sepCount == 10) // separator immediately before ISA11
+                    repetitionSep = i + 1 < isaInput.Length ? isaInput[i + 1] : '^';
+
                 if (sepCount == X12Constants.IsaElementCount - 1)
                 {
                     char componentSep = i + 1 < isaInput.Length ? isaInput[i + 1] : ':';
                     char segmentTerm  = i + 2 < isaInput.Length ? isaInput[i + 2] : '~';
-                    return new X12Delimiters(elementSep, componentSep, segmentTerm);
+                    return new X12Delimiters(elementSep, componentSep, segmentTerm, repetitionSep);
                 }
             }
         }
 
         // Malformed ISA — enough chars but fewer than 15 element separators
-        return new X12Delimiters(elementSep, ':', '~');
+        return new X12Delimiters(elementSep, ':', '~', repetitionSep);
     }
 }

--- a/src/X12Net.Domain/Core/X12Segment.cs
+++ b/src/X12Net.Domain/Core/X12Segment.cs
@@ -24,6 +24,14 @@ public sealed class X12Segment
     /// <summary>Gets the element at <paramref name="index"/> (1-based, matching X12 field numbering).</summary>
     public string this[int index] => Elements[index - 1];
 
+    /// <summary>
+    /// Returns the individual repetitions within the element at <paramref name="elementIndex"/>
+    /// by splitting on <paramref name="repetitionSeparator"/>.
+    /// When the element contains no repetition separator the result has a single entry.
+    /// </summary>
+    public IReadOnlyList<string> GetRepetitions(int elementIndex, char repetitionSeparator) =>
+        Elements[elementIndex - 1].Split(repetitionSeparator);
+
     /// <summary>Serializes the segment back to EDI text.</summary>
     internal string ToEdi(X12Delimiters delimiters)
     {

--- a/src/X12Net.Domain/Core/X12TokenType.cs
+++ b/src/X12Net.Domain/Core/X12TokenType.cs
@@ -14,4 +14,7 @@ public enum X12TokenType
 
     /// <summary>Marks the end of a segment.</summary>
     SegmentTerminator,
+
+    /// <summary>A repeated value within an element, separated by the repetition separator (ISA11).</summary>
+    RepetitionData,
 }

--- a/test/X12Net.Tests/Core/X12RepetitionSeparatorTests.cs
+++ b/test/X12Net.Tests/Core/X12RepetitionSeparatorTests.cs
@@ -1,0 +1,90 @@
+using woliver13.X12Net.Core;
+
+namespace woliver13.X12Net.Tests.Core;
+
+public class X12RepetitionSeparatorTests
+{
+    // Standard 005010 interchange with ^ as ISA11 (repetition separator)
+    private const string StandardInterchange =
+        "ISA*00*          *00*          *ZZ*SENDER         *ZZ*RECEIVER       *201909*1200*^*00501*000000001*0*P*:~" +
+        "GS*FA*SENDER*RECEIVER*20190901*1200*1*X*005010X231A1~" +
+        "IEA*1*000000001~";
+
+    // Non-standard interchange using | as element sep and + as repetition separator (ISA11)
+    private const string NonstandardRepSepInterchange =
+        "ISA|00|          |00|          |ZZ|SENDER         |ZZ|RECEIVER       |201909|1200|+|00501|000000001|0|P|:\n" +
+        "GS|FA|SENDER|RECEIVER|20190901|1200|1|X|005010X231A1\n" +
+        "IEA|1|000000001\n";
+
+    [Fact]
+    public void IsaParser_extracts_repetition_separator_from_standard_interchange()
+    {
+        var d = X12Delimiters.FromIsa(StandardInterchange);
+
+        d.RepetitionSeparator.ShouldBe('^');
+    }
+
+    [Fact]
+    public void IsaParser_extracts_nonstandard_repetition_separator()
+    {
+        var d = X12Delimiters.FromIsa(NonstandardRepSepInterchange);
+
+        d.RepetitionSeparator.ShouldBe('+');
+    }
+
+    [Fact]
+    public void Delimiters_default_has_caret_as_repetition_separator()
+    {
+        X12Delimiters.Default.RepetitionSeparator.ShouldBe('^');
+    }
+
+    [Fact]
+    public void Segment_GetRepetitions_splits_element_on_repetition_separator()
+    {
+        // GS03 contains two repetitions: "SENDER" and "ALIAS" joined by ^
+        const string edi = "GS*FA*SENDER*SENDER^ALIAS*20190901*1200*1*X*005010~";
+        var segment = X12SegmentParser.ParseAll(edi, X12Delimiters.Default).First();
+
+        var reps = segment.GetRepetitions(3, '^');
+
+        reps.Count.ShouldBe(2);
+        reps[0].ShouldBe("SENDER");
+        reps[1].ShouldBe("ALIAS");
+    }
+
+    [Fact]
+    public void Segment_GetRepetitions_returns_single_entry_when_no_repetition_present()
+    {
+        const string edi = "GS*FA*SENDER*RECEIVER*20190901*1200*1*X*005010~";
+        var segment = X12SegmentParser.ParseAll(edi, X12Delimiters.Default).First();
+
+        var reps = segment.GetRepetitions(3, '^');
+
+        reps.Count.ShouldBe(1);
+        reps[0].ShouldBe("RECEIVER");
+    }
+
+    [Fact]
+    public void Delimiters_FromIsa_preserves_repetition_separator_through_full_parse()
+    {
+        // Interchange where ISA11 is + (non-default)
+        var d = X12Delimiters.FromIsa(NonstandardRepSepInterchange);
+        var segments = X12SegmentParser.ParseAll(NonstandardRepSepInterchange, d).ToList();
+        var gs = segments.First(s => s.SegmentId == "GS");
+
+        // GS02 has two repetitions joined by +
+        const string ediWithRep =
+            "ISA|00|          |00|          |ZZ|SENDER         |ZZ|RECEIVER       |201909|1200|+|00501|000000001|0|P|:\n" +
+            "GS|FA|SENDER+ALIAS|RECEIVER|20190901|1200|1|X|005010X231A1\n" +
+            "IEA|1|000000001\n";
+
+        var d2 = X12Delimiters.FromIsa(ediWithRep);
+        var segs = X12SegmentParser.ParseAll(ediWithRep, d2).ToList();
+        var gs2 = segs.First(s => s.SegmentId == "GS");
+
+        var reps = gs2.GetRepetitions(2, d2.RepetitionSeparator);
+        reps.Count.ShouldBe(2);
+        reps[0].ShouldBe("SENDER");
+        reps[1].ShouldBe("ALIAS");
+    }
+}


### PR DESCRIPTION
## Summary

- `X12Delimiters` gains a `RepetitionSeparator` property (default `'^'`, backward-compatible optional 4th constructor parameter); `Equals`/`GetHashCode`/`ToString` updated
- `X12IsaParser` now captures ISA11 (the repetition separator field) and populates `X12Delimiters.RepetitionSeparator`, so non-default separators are correctly reflected after parsing any 005010+ interchange
- `X12TokenType` gains a `RepetitionData` enum value documenting the concept for future tokenizer use
- `X12Segment.GetRepetitions(int elementIndex, char repetitionSeparator)` splits a raw element value on the repetition separator, giving callers a typed accessor instead of manual string splitting

## What was NOT changed

The tokenizer was intentionally left unchanged. Splitting at the repetition level inside the tokenizer would require restructuring `X12SegmentParser`'s element-assembly logic and would change the `X12Segment.Elements` contract. `GetRepetitions` achieves the same consumer-facing result without that disruption.

## Test plan

- [x] `IsaParser_extracts_repetition_separator_from_standard_interchange` — `^` extracted from standard ISA11
- [x] `IsaParser_extracts_nonstandard_repetition_separator` — `+` extracted when ISA11 = `+`
- [x] `Delimiters_default_has_caret_as_repetition_separator`
- [x] `Segment_GetRepetitions_splits_element_on_repetition_separator`
- [x] `Segment_GetRepetitions_returns_single_entry_when_no_repetition_present`
- [x] `Delimiters_FromIsa_preserves_repetition_separator_through_full_parse`
- [x] Full suite: 283 passing, 0 failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)