### PR TITLE
Fix #41: add GetRepetitions to Hl7Segment and Hl7MutableSegment

### DIFF
--- a/src/HL7Net/Core/Hl7Segment.cs
+++ b/src/HL7Net/Core/Hl7Segment.cs
@@ -26,4 +26,12 @@ public sealed class Hl7Segment
 
     /// <summary>The number of fields in this segment.</summary>
     public int FieldCount => _fields.Count;
+
+    /// <summary>
+    /// Returns the individual repetitions within the field at <paramref name="fieldIndex"/>
+    /// by splitting on <paramref name="repetitionSeparator"/>.
+    /// When the field contains no repetition separator the result has a single entry.
+    /// </summary>
+    public IReadOnlyList<string> GetRepetitions(int fieldIndex, char repetitionSeparator) =>
+        this[fieldIndex].Split(repetitionSeparator);
 }

--- a/src/HL7Net/DOM/Hl7MutableSegment.cs
+++ b/src/HL7Net/DOM/Hl7MutableSegment.cs
@@ -32,6 +32,14 @@ public sealed class Hl7MutableSegment
     /// <summary>The number of fields in this segment.</summary>
     public int FieldCount => _fields.Count;
 
+    /// <summary>
+    /// Returns the individual repetitions within the field at <paramref name="fieldIndex"/>
+    /// by splitting on <paramref name="repetitionSeparator"/>.
+    /// When the field contains no repetition separator the result has a single entry.
+    /// </summary>
+    public IReadOnlyList<string> GetRepetitions(int fieldIndex, char repetitionSeparator) =>
+        this[fieldIndex].Split(repetitionSeparator);
+
     /// <summary>All field values (0-based internally).</summary>
     internal IReadOnlyList<string> Fields => _fields;
 }

--- a/test/HL7Net.Tests/Core/Hl7RepetitionTests.cs
+++ b/test/HL7Net.Tests/Core/Hl7RepetitionTests.cs
@@ -1,0 +1,55 @@
+using woliver13.HL7Net.Core;
+using woliver13.HL7Net.DOM;
+using Shouldly;
+using Xunit;
+
+namespace HL7Net.Tests.Core;
+
+public class Hl7RepetitionTests
+{
+    // Standard HL7 delimiters: field=|, component=^, repetition=~, escape=\, sub=&
+    private static readonly char RepSep = '~';
+
+    // ── Cycle 1 / 2 ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void Hl7Segment_GetRepetitions_splits_field_on_repetition_separator()
+    {
+        // PID-3 contains two patient identifiers separated by ~
+        var segment = new Hl7Segment("PID",
+            new[] { "", "", "12345^^^MRN~98765^^^EPI", "" });
+
+        var reps = segment.GetRepetitions(3, RepSep);
+
+        reps.Count.ShouldBe(2);
+        reps[0].ShouldBe("12345^^^MRN");
+        reps[1].ShouldBe("98765^^^EPI");
+    }
+
+    [Fact]
+    public void Hl7Segment_GetRepetitions_returns_single_entry_when_no_repetition_present()
+    {
+        var segment = new Hl7Segment("NK1",
+            new[] { "1", "SMITH^JOHN", "SPO" });
+
+        var reps = segment.GetRepetitions(3, RepSep);
+
+        reps.Count.ShouldBe(1);
+        reps[0].ShouldBe("SPO");
+    }
+
+    // ── Cycle 3 ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Hl7MutableSegment_GetRepetitions_splits_field_on_repetition_separator()
+    {
+        var segment = new Hl7MutableSegment("PID",
+            new[] { "", "", "12345^^^MRN~98765^^^EPI" });
+
+        var reps = segment.GetRepetitions(3, RepSep);
+
+        reps.Count.ShouldBe(2);
+        reps[0].ShouldBe("12345^^^MRN");
+        reps[1].ShouldBe("98765^^^EPI");
+    }
+}


### PR DESCRIPTION
## Summary

- `Hl7Segment.GetRepetitions(int fieldIndex, char repetitionSeparator)` splits the raw field value on the repetition separator and returns the individual repetitions
- `Hl7MutableSegment.GetRepetitions(int fieldIndex, char repetitionSeparator)` provides the same accessor on the mutable type
- Callers pass `Hl7Delimiters.RepetitionSeparator` (already populated from MSH-2) rather than hard-coding the separator character
- The raw 1-based `this[int]` indexer is unchanged — it remains the fast path for callers that don't need repetition splitting

## Test plan

- [x] Cycle 1: `Hl7Segment_GetRepetitions_splits_field_on_repetition_separator` — RED → GREEN
- [x] Cycle 2: `Hl7Segment_GetRepetitions_returns_single_entry_when_no_repetition_present` — GREEN (characterisation)
- [x] Cycle 3: `Hl7MutableSegment_GetRepetitions_splits_field_on_repetition_separator` — RED → GREEN
- [x] Full suite: 317 passing (283 X12Net + 34 HL7Net), 0 failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)